### PR TITLE
23 break up tests basic

### DIFF
--- a/test/basic/abs_test.cpp
+++ b/test/basic/abs_test.cpp
@@ -7,96 +7,243 @@
  */
 
 #include <gtest/gtest.h>
-#include <ccmath/ccmath.hpp>
+#include <ccmath/math/basic/abs.hpp>
 #include <cmath>
 #include <limits>
 
-TEST(CcmathBasicTests, AbsStaticAssert)
+namespace
 {
-    // Verify that ccm::abs works with static_assert
-    static_assert(ccm::abs(1) == 1, "abs has failed testing that it is static_assert-able!");
+
+	using testing::TestWithParam;
+	using testing::ValuesIn;
+
+	template <typename T>
+	struct AbsTestParams
+	{
+		T input{};
+		T expected{};
+	};
+
+	const std::vector<AbsTestParams<double>> kAbsDoubleTestParams{
+
+		// Floating point whole values
+		{1.0, std::abs(1.0)},
+		{-1.0, std::abs(-1.0)},
+		{2.0, std::abs(2.0)},
+		{-2.0, std::abs(-2.0)},
+		{4.0, std::abs(4.0)},
+		{-4.0, std::abs(-4.0)},
+		{8.0, std::abs(8.0)},
+		{-8.0, std::abs(-8.0)},
+		{16.0, std::abs(16.0)},
+		{-16.0, std::abs(-16.0)},
+		{32.0, std::abs(32.0)},
+		{-32.0, std::abs(-32.0)},
+
+		// Testing zeroes
+		{0.0, std::abs(0.0)},
+		{-0.0, std::abs(-0.0)},
+
+		// Floating point non-whole values
+		{1.12345, std::abs(1.12345)},
+		{-1.12345, std::abs(1.12345)},
+		{74.5928, std::abs(74.5928)},
+		{-74.5928, std::abs(-74.5928)},
+
+		// Edge cases
+		{std::numeric_limits<double>::min(), std::abs(std::numeric_limits<double>::min())},
+		{std::numeric_limits<double>::max(), std::abs(std::numeric_limits<double>::max())},
+		{std::numeric_limits<double>::denorm_min(), std::abs(std::numeric_limits<double>::denorm_min())},
+		{-std::numeric_limits<double>::denorm_min(), std::abs(-std::numeric_limits<double>::denorm_min())},
+		{std::numeric_limits<double>::infinity(), std::abs(std::numeric_limits<double>::infinity())},
+		{-std::numeric_limits<double>::infinity(), std::abs(-std::numeric_limits<double>::infinity())},
+		{-std::numeric_limits<double>::max() * 10, std::abs(-std::numeric_limits<double>::max() * 10)},
+		{std::numeric_limits<double>::max() * 10, std::abs(std::numeric_limits<double>::max() * 10)},
+		{std::numeric_limits<double>::quiet_NaN(), std::abs(std::numeric_limits<double>::quiet_NaN())},
+	};
+
+	const std::vector<AbsTestParams<float>> kAbsFloatTestParams{
+
+		// Floating point whole values
+		{1.0F, std::abs(1.0F)},
+		{-1.0F, std::abs(-1.0F)},
+		{2.0F, std::abs(2.0F)},
+		{-2.0F, std::abs(-2.0F)},
+		{4.0F, std::abs(4.0F)},
+		{-4.0F, std::abs(-4.0F)},
+		{8.0F, std::abs(8.0F)},
+		{-8.0F, std::abs(-8.0F)},
+		{16.0F, std::abs(16.0F)},
+		{-16.0F, std::abs(-16.0F)},
+		{32.0F, std::abs(32.0F)},
+		{-32.0F, std::abs(-32.0F)},
+
+		// Testing zeroes
+		{0.0F, std::abs(0.0F)},
+		{-0.0F, std::abs(-0.0F)},
+
+		// Floating point non-whole values
+		{1.12345F, std::abs(1.12345F)},
+		{-1.12345F, std::abs(1.12345F)},
+		{74.5928F, std::abs(74.5928F)},
+		{-74.5928F, std::abs(-74.5928F)},
+
+		// Edge cases
+		{std::numeric_limits<float>::min(), std::abs(std::numeric_limits<float>::min())},
+		{std::numeric_limits<float>::max(), std::abs(std::numeric_limits<float>::max())},
+		{std::numeric_limits<float>::denorm_min(), std::abs(std::numeric_limits<float>::denorm_min())},
+		{-std::numeric_limits<float>::denorm_min(), std::abs(-std::numeric_limits<float>::denorm_min())},
+		{std::numeric_limits<float>::infinity(), std::abs(std::numeric_limits<float>::infinity())},
+		{-std::numeric_limits<float>::infinity(), std::abs(-std::numeric_limits<float>::infinity())},
+		{-std::numeric_limits<float>::max() * 10, std::abs(-std::numeric_limits<float>::max() * 10)},
+		{std::numeric_limits<float>::max() * 10, std::abs(std::numeric_limits<float>::max() * 10)},
+		{std::numeric_limits<float>::quiet_NaN(), std::abs(std::numeric_limits<float>::quiet_NaN())},
+	};
+
+	const std::vector<AbsTestParams<long double>> kAbsLongDoubleTestParams{
+
+		// Floating point whole values
+		{1.0L, std::abs(1.0L)},
+		{-1.0L, std::abs(-1.0L)},
+		{2.0L, std::abs(2.0L)},
+		{-2.0L, std::abs(-2.0L)},
+		{4.0L, std::abs(4.0L)},
+		{-4.0L, std::abs(-4.0L)},
+		{8.0L, std::abs(8.0L)},
+		{-8.0L, std::abs(-8.0L)},
+		{16.0L, std::abs(16.0L)},
+		{-16.0L, std::abs(-16.0L)},
+		{32.0L, std::abs(32.0L)},
+		{-32.0L, std::abs(-32.0L)},
+
+		// Testing zeroes
+		{0.0L, std::abs(0.0L)},
+		{-0.0L, std::abs(-0.0L)},
+
+		// Floating point non-whole values
+		{1.12345L, std::abs(1.12345L)},
+		{-1.12345L, std::abs(1.12345L)},
+		{74.5928L, std::abs(74.5928L)},
+		{-74.5928L, std::abs(-74.5928L)},
+
+		// Edge cases
+		{std::numeric_limits<long double>::min(), std::abs(std::numeric_limits<long double>::min())},
+		{std::numeric_limits<long double>::max(), std::abs(std::numeric_limits<long double>::max())},
+		{std::numeric_limits<long double>::denorm_min(), std::abs(std::numeric_limits<long double>::denorm_min())},
+		{-std::numeric_limits<long double>::denorm_min(), std::abs(-std::numeric_limits<long double>::denorm_min())},
+		{std::numeric_limits<long double>::infinity(), std::abs(std::numeric_limits<long double>::infinity())},
+		{-std::numeric_limits<long double>::infinity(), std::abs(-std::numeric_limits<long double>::infinity())},
+		{-std::numeric_limits<long double>::max() * 10, std::abs(-std::numeric_limits<long double>::max() * 10)},
+		{std::numeric_limits<long double>::max() * 10, std::abs(std::numeric_limits<long double>::max() * 10)},
+		{std::numeric_limits<long double>::quiet_NaN(), std::abs(std::numeric_limits<long double>::quiet_NaN())},
+	};
+
+	const std::vector<AbsTestParams<int>> kAbsIntTestParams{
+
+		{1, std::abs(1)},
+		{-1, std::abs(-1)},
+		{2, std::abs(2)},
+		{-2, std::abs(-2)},
+		{4, std::abs(4)},
+		{-4, std::abs(-4)},
+		{8, std::abs(8)},
+		{-8, std::abs(-8)},
+		{16, std::abs(16)},
+		{-16, std::abs(-16)},
+		{32, std::abs(32)},
+		{-32, std::abs(-32)},
+
+		// Testing zeroes
+		{0, std::abs(0)},
+
+		// Edge cases
+		{std::numeric_limits<int>::max(), std::abs(std::numeric_limits<int>::max())},
+		{std::numeric_limits<int>::denorm_min(), std::abs(std::numeric_limits<int>::denorm_min())},
+		{-std::numeric_limits<int>::denorm_min(), std::abs(-std::numeric_limits<int>::denorm_min())},
+		{std::numeric_limits<int>::infinity(), std::abs(std::numeric_limits<int>::infinity())},
+		{-std::numeric_limits<int>::infinity(), std::abs(-std::numeric_limits<int>::infinity())},
+		{-std::numeric_limits<int>::max() * 10, std::abs(-std::numeric_limits<int>::max() * 10)},
+		{std::numeric_limits<int>::max() * 10, std::abs(std::numeric_limits<int>::max() * 10)},
+	};
+
+} // namespace
+
+class CcmathAbsDoubleTests : public TestWithParam<AbsTestParams<double>>
+{
+};
+class CcmathAbsFloatTests : public TestWithParam<AbsTestParams<float>>
+{
+};
+class CcmathAbsLongDoubleTests : public TestWithParam<AbsTestParams<long double>>
+{
+};
+class CcmathAbsIntTests : public TestWithParam<AbsTestParams<int>>
+{
+};
+
+INSTANTIATE_TEST_SUITE_P(AbsDoubleTests, CcmathAbsDoubleTests, ValuesIn(kAbsDoubleTestParams));
+INSTANTIATE_TEST_SUITE_P(AbsFloatTests, CcmathAbsFloatTests, ValuesIn(kAbsFloatTestParams));
+INSTANTIATE_TEST_SUITE_P(AbsLongDoubleTests, CcmathAbsLongDoubleTests, ValuesIn(kAbsLongDoubleTestParams));
+INSTANTIATE_TEST_SUITE_P(AbsIntTests, CcmathAbsIntTests, ValuesIn(kAbsIntTestParams));
+
+TEST_P(CcmathAbsDoubleTests, AbsWithDoubleReturnsAppropriateValue)
+{
+	// Arrange
+	const auto & param{GetParam()};
+
+	// Act
+	const auto actual{ccm::abs(param.input)};
+
+	// Assert
+	if (std::isnan(param.expected)) { EXPECT_TRUE(std::isnan(actual)) << "ccm::abs(" << param.input << ") expected to be NaN. Instead got " << actual << "."; }
+	else { EXPECT_EQ(actual, param.expected) << "ccm::abs(" << param.input << ") expected to equal " << param.expected << ". Instead got " << actual << "."; }
 }
 
-TEST(CcmathBasicTests, AbsZeroSign)
+TEST_P(CcmathAbsFloatTests, AbsWithFloatReturnsAppropriateValue)
 {
-	EXPECT_EQ(ccm::abs(-0.0), std::abs(-0.0));
-	EXPECT_EQ(ccm::abs(0), std::abs(0));
+	// Arrange
+	const auto & param{GetParam()};
+
+	// Act
+	const auto actual{ccm::abs(param.input)};
+
+	// Assert
+	if (std::isnan(param.expected)) { EXPECT_TRUE(std::isnan(actual)) << "ccm::abs(" << param.input << ") expected to be NaN. Instead got " << actual << "."; }
+	else { EXPECT_EQ(actual, param.expected) << "ccm::abs(" << param.input << ") expected to equal " << param.expected << ". Instead got " << actual << "."; }
 }
 
-TEST(CcmathBasicTests, AbsDouble)
+TEST_P(CcmathAbsLongDoubleTests, AbsWithLongDoubleReturnsAppropriateValue)
 {
-	EXPECT_EQ(ccm::abs(1.0), std::abs(1.0));
-	EXPECT_EQ(ccm::abs(-1.0), std::abs(-1.0));
-	EXPECT_EQ(ccm::abs(2.0), std::abs(2.0));
-	EXPECT_EQ(ccm::abs(-2.0), std::abs(-2.0));
-	EXPECT_EQ(ccm::abs(4.0), std::abs(4.0));
-	EXPECT_EQ(ccm::abs(-4.0), std::abs(-4.0));
-	EXPECT_EQ(ccm::abs(8.0), std::abs(8.0));
-	EXPECT_EQ(ccm::abs(-8.0), std::abs(-8.0));
-	EXPECT_EQ(ccm::abs(16.0), std::abs(16.0));
-	EXPECT_EQ(ccm::abs(-16.0), std::abs(-16.0));
-	EXPECT_EQ(ccm::abs(32.0), std::abs(32.0));
-	EXPECT_EQ(ccm::abs(-32.0), std::abs(-32.0));
+	// Arrange
+	const auto & param{GetParam()};
+
+	// Act
+	const auto actual{ccm::abs(param.input)};
+
+	// Assert
+	if (std::isnan(param.expected)) { EXPECT_TRUE(std::isnan(actual)) << "ccm::abs(" << param.input << ") expected to be NaN. Instead got " << actual << "."; }
+	else { EXPECT_EQ(actual, param.expected) << "ccm::abs(" << param.input << ") expected to equal " << param.expected << ". Instead got " << actual << "."; }
 }
 
-TEST(CcmathBasicTests, AbsFloat)
+TEST_P(CcmathAbsIntTests, AbsWithIntReturnsAppropriateValue)
 {
-    EXPECT_EQ(ccm::abs(1.0F), std::abs(1.0F));
-    EXPECT_EQ(ccm::abs(-1.0F), std::abs(-1.0F));
-    EXPECT_EQ(ccm::abs(2.0F), std::abs(2.0F));
-    EXPECT_EQ(ccm::abs(-2.0F), std::abs(-2.0F));
-    EXPECT_EQ(ccm::abs(4.0F), std::abs(4.0F));
-    EXPECT_EQ(ccm::abs(-4.0F), std::abs(-4.0F));
-    EXPECT_EQ(ccm::abs(8.0F), std::abs(8.0F));
-    EXPECT_EQ(ccm::abs(-8.0F), std::abs(-8.0F));
-    EXPECT_EQ(ccm::abs(16.0F), std::abs(16.0F));
-    EXPECT_EQ(ccm::abs(-16.0F), std::abs(-16.0F));
-    EXPECT_EQ(ccm::abs(32.0F), std::abs(32.0F));
-    EXPECT_EQ(ccm::abs(-32.0F), std::abs(-32.0F));
+	// Arrange
+	const auto & param{GetParam()};
+
+	// Act
+	const auto actual{ccm::abs(param.input)};
+
+	// Assert
+	EXPECT_EQ(actual, param.expected) << "ccm::abs(" << param.input << ") expected to equal " << param.expected << ". Instead got " << actual << ".";
 }
 
-TEST(CcmathBasicTests, AbsLongDouble)
+TEST(CcmathBasicTests, CcmAbsCanBeEvaluatedAtCompileTime)
 {
-	EXPECT_EQ(ccm::abs(1.0L), std::abs(1.0L));
-    EXPECT_EQ(ccm::abs(-1.0L), std::abs(-1.0L));
-    EXPECT_EQ(ccm::abs(2.0L), std::abs(2.0L));
-    EXPECT_EQ(ccm::abs(-2.0L), std::abs(-2.0L));
-    EXPECT_EQ(ccm::abs(4.0L), std::abs(4.0L));
-    EXPECT_EQ(ccm::abs(-4.0L), std::abs(-4.0L));
-    EXPECT_EQ(ccm::abs(8.0L), std::abs(8.0L));
-    EXPECT_EQ(ccm::abs(-8.0L), std::abs(-8.0L));
-    EXPECT_EQ(ccm::abs(16.0L), std::abs(16.0L));
-    EXPECT_EQ(ccm::abs(-16.0L), std::abs(-16.0L));
-    EXPECT_EQ(ccm::abs(32.0L), std::abs(32.0L));
-    EXPECT_EQ(ccm::abs(-32.0L), std::abs(-32.0L));
-}
+	// Verify that ccm::abs works with static_assert
 
-TEST(CcmathBasicTests, AbsInt)
-{
-    EXPECT_EQ(ccm::abs(1), std::abs(1));
-    EXPECT_EQ(ccm::abs(-1), std::abs(-1));
-    EXPECT_EQ(ccm::abs(2), std::abs(2));
-    EXPECT_EQ(ccm::abs(-2), std::abs(-2));
-    EXPECT_EQ(ccm::abs(4), std::abs(4));
-    EXPECT_EQ(ccm::abs(-4), std::abs(-4));
-    EXPECT_EQ(ccm::abs(8), std::abs(8));
-    EXPECT_EQ(ccm::abs(-8), std::abs(-8));
-    EXPECT_EQ(ccm::abs(16), std::abs(16));
-    EXPECT_EQ(ccm::abs(-16), std::abs(-16));
-    EXPECT_EQ(ccm::abs(32), std::abs(32));
-    EXPECT_EQ(ccm::abs(-32), std::abs(-32));
-}
+	// Act
+	constexpr auto abs{ccm::abs(1)};
 
-TEST(CcmathBasicTests, AbsEdgeCases)
-{
-	// TODO: Implement more edge cases for ABS.
-	EXPECT_EQ(ccm::abs(std::numeric_limits<int>::min()), std::abs(std::numeric_limits<int>::min()));
-    EXPECT_EQ(ccm::abs(std::numeric_limits<int>::max()), std::abs(std::numeric_limits<int>::max()));
-    EXPECT_EQ(ccm::abs(std::numeric_limits<float>::min()), std::abs(std::numeric_limits<float>::min()));
-    EXPECT_EQ(ccm::abs(std::numeric_limits<float>::max()), std::abs(std::numeric_limits<float>::max()));
-    EXPECT_EQ(ccm::abs(std::numeric_limits<double>::min()), std::abs(std::numeric_limits<double>::min()));
-    EXPECT_EQ(ccm::abs(std::numeric_limits<double>::max()), std::abs(std::numeric_limits<double>::max()));
-    EXPECT_EQ(ccm::abs(std::numeric_limits<long double>::min()), std::abs(std::numeric_limits<long double>::min()));
-    EXPECT_EQ(ccm::abs(std::numeric_limits<long double>::max()), std::abs(std::numeric_limits<long double>::max()));
+	// Assert
+	static_assert(abs == 1, "abs has failed testing that it is static_assert-able!");
 }
-

--- a/test/basic/fdim_test.cpp
+++ b/test/basic/fdim_test.cpp
@@ -12,63 +12,185 @@
 #include <cmath>
 #include <limits>
 
-TEST(CcmathBasicTests, FdimStaticAssert)
+namespace
 {
-	static_assert(ccm::fdim(1.0, 1.0) == 0.0, "fdim has failed testing that it is static_assert-able!");
+
+	using testing::TestWithParam;
+	using testing::ValuesIn;
+
+	template <typename T>
+	struct FDimTestParams
+	{
+		T x{};
+		T y{};
+		T expected{};
+	};
+
+	const std::vector<FDimTestParams<double>> kFDimDoubleTestParams{
+		{1.0, 1.0, std::fdim(1.0, 1.0)},
+		{2.0, 2.0, std::fdim(2.0, 2.0)},
+		{4.0, 4.0, std::fdim(4.0, 4.0)},
+		{8.0, 8.0, std::fdim(8.0, 8.0)},
+		{16.0, 16.0, std::fdim(16.0, 16.0)},
+		{32.0, 32.0, std::fdim(32.0, 32.0)},
+
+		{1.0, 0.0, std::fdim(1.0, 0.0)},
+		{0.0, 1.0, std::fdim(0.0, 1.0)},
+		{0.0, 0.0, std::fdim(0.0, 0.0)},
+		{-1.0, 1.0, std::fdim(-1.0, 1.0)},
+		{1.0, -1.0, std::fdim(1.0, -1.0)},
+		{-1.0, -1.0, std::fdim(-1.0, -1.0)},
+
+		// Edge cases
+		{std::numeric_limits<double>::infinity(), 1.0, std::fdim(std::numeric_limits<double>::infinity(), 1.0)},
+		{1.0, std::numeric_limits<double>::infinity(), std::fdim(1.0, std::numeric_limits<double>::infinity())},
+		{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity(),
+		 std::fdim(std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity())},
+		{std::numeric_limits<double>::quiet_NaN(), 1.0, std::fdim(std::numeric_limits<double>::quiet_NaN(), 1.0)},
+		{1.0, std::numeric_limits<double>::quiet_NaN(), std::fdim(1.0, std::numeric_limits<double>::quiet_NaN())},
+		{std::numeric_limits<double>::max(), std::numeric_limits<double>::max() - 1.0,
+		 std::fdim(std::numeric_limits<double>::max(), std::numeric_limits<double>::max() - 1.0)},
+		{-std::numeric_limits<double>::max(), std::numeric_limits<double>::max(),
+		 std::fdim(-std::numeric_limits<double>::max(), std::numeric_limits<double>::max())},
+	};
+
+	const std::vector<FDimTestParams<float>> kFDimFloatTestParams{
+		{1.0F, 1.0F, std::fdim(1.0F, 1.0F)},
+		{2.0F, 2.0F, std::fdim(2.0F, 2.0F)},
+		{4.0F, 4.0F, std::fdim(4.0F, 4.0F)},
+		{8.0F, 8.0F, std::fdim(8.0F, 8.0F)},
+		{16.0F, 16.0F, std::fdim(16.0F, 16.0F)},
+		{32.0F, 32.0F, std::fdim(32.0F, 32.0F)},
+
+		{1.0F, 0.0F, std::fdim(1.0F, 0.0F)},
+		{0.0F, 1.0F, std::fdim(0.0F, 1.0F)},
+		{0.0F, 0.0F, std::fdim(0.0F, 0.0F)},
+		{-1.0F, 1.0F, std::fdim(-1.0F, 1.0F)},
+		{1.0F, -1.0F, std::fdim(1.0F, -1.0F)},
+		{-1.0F, -1.0F, std::fdim(-1.0F, -1.0F)},
+
+		// Edge cases
+		{std::numeric_limits<float>::infinity(), 1.0F, std::fdim(std::numeric_limits<float>::infinity(), 1.0F)},
+		{1.0F, std::numeric_limits<float>::infinity(), std::fdim(1.0F, std::numeric_limits<float>::infinity())},
+		{std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
+		 std::fdim(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity())},
+		{std::numeric_limits<float>::quiet_NaN(), 1.0F, std::fdim(std::numeric_limits<float>::quiet_NaN(), 1.0F)},
+		{1.0F, std::numeric_limits<float>::quiet_NaN(), std::fdim(1.0F, std::numeric_limits<float>::quiet_NaN())},
+		{std::numeric_limits<float>::max(), std::numeric_limits<float>::max() - 1.0F,
+		 std::fdim(std::numeric_limits<float>::max(), std::numeric_limits<float>::max() - 1.0F)},
+		{-std::numeric_limits<float>::max(), std::numeric_limits<float>::max(),
+		 std::fdim(-std::numeric_limits<float>::max(), std::numeric_limits<float>::max())},
+	};
+
+	const std::vector<FDimTestParams<long double>> kFDimLongDoubleTestParams{
+		{1.0L, 1.0L, std::fdim(1.0L, 1.0L)},
+		{2.0L, 2.0L, std::fdim(2.0L, 2.0L)},
+		{4.0L, 4.0L, std::fdim(4.0L, 4.0L)},
+		{8.0L, 8.0L, std::fdim(8.0L, 8.0L)},
+		{16.0L, 16.0L, std::fdim(16.0L, 16.0L)},
+		{32.0L, 32.0L, std::fdim(32.0L, 32.0L)},
+
+		{1.0L, 0.0L, std::fdim(1.0L, 0.0L)},
+		{0.0L, 1.0L, std::fdim(0.0L, 1.0L)},
+		{0.0L, 0.0L, std::fdim(0.0L, 0.0L)},
+		{-1.0L, 1.0L, std::fdim(-1.0L, 1.0L)},
+		{1.0L, -1.0L, std::fdim(1.0L, -1.0L)},
+		{-1.0L, -1.0L, std::fdim(-1.0L, -1.0L)},
+
+		// Edge cases
+		{std::numeric_limits<long double>::infinity(), 1.0L, std::fdim(std::numeric_limits<long double>::infinity(), 1.0L)},
+		{1.0L, std::numeric_limits<long double>::infinity(), std::fdim(1.0L, std::numeric_limits<long double>::infinity())},
+		{std::numeric_limits<long double>::infinity(), std::numeric_limits<long double>::infinity(),
+		 std::fdim(std::numeric_limits<long double>::infinity(), std::numeric_limits<long double>::infinity())},
+		{std::numeric_limits<long double>::quiet_NaN(), 1.0L, std::fdim(std::numeric_limits<long double>::quiet_NaN(), 1.0L)},
+		{1.0L, std::numeric_limits<long double>::quiet_NaN(), std::fdim(1.0L, std::numeric_limits<long double>::quiet_NaN())},
+		{std::numeric_limits<long double>::max(), std::numeric_limits<long double>::max() - 1.0L,
+		 std::fdim(std::numeric_limits<long double>::max(), std::numeric_limits<long double>::max() - 1.0L)},
+		{-std::numeric_limits<long double>::max(), std::numeric_limits<long double>::max(),
+		 std::fdim(-std::numeric_limits<long double>::max(), std::numeric_limits<long double>::max())},
+	};
+
+} // namespace
+
+class CcmathFDimDoubleTests : public TestWithParam<FDimTestParams<double>>
+{
+};
+class CcmathFDimFloatTests : public TestWithParam<FDimTestParams<float>>
+{
+};
+class CcmathFDimLongDoubleTests : public TestWithParam<FDimTestParams<long double>>
+{
+};
+
+INSTANTIATE_TEST_SUITE_P(FDimDoubleTests, CcmathFDimDoubleTests, ValuesIn(kFDimDoubleTestParams));
+INSTANTIATE_TEST_SUITE_P(FDimFloatTests, CcmathFDimFloatTests, ValuesIn(kFDimFloatTestParams));
+INSTANTIATE_TEST_SUITE_P(FDimLongDoubleTests, CcmathFDimLongDoubleTests, ValuesIn(kFDimLongDoubleTestParams));
+
+TEST_P(CcmathFDimDoubleTests, FDimWithDoubleReturnsApropriateValue)
+{
+	// Arrange
+	const auto & param{GetParam()};
+
+	// Act
+	const auto actual{ccm::fdim(param.x, param.y)};
+
+	// Assert
+	if (std::isnan(param.expected))
+	{
+		EXPECT_TRUE(std::isnan(actual)) << "ccm::fdim(" << param.x << ", " << param.y << ") expected to be NaN. Instead got " << actual << ".";
+	}
+	else
+	{
+		EXPECT_EQ(actual, param.expected) << "ccm::fdim(" << param.x << ", " << param.y << ") expected to equal " << param.expected << ". Instead got "
+										  << actual << ".";
+	}
 }
 
-TEST(CcmathBasicTests, FdimDouble)
+TEST_P(CcmathFDimFloatTests, FDimWithFloatReturnsAppropriateValue)
 {
-	EXPECT_EQ(ccm::fdim(1.0, 1.0), std::fdim(1.0, 1.0));
-	EXPECT_EQ(ccm::fdim(2.0, 2.0), std::fdim(2.0, 2.0));
-	EXPECT_EQ(ccm::fdim(4.0, 4.0), std::fdim(4.0, 4.0));
-	EXPECT_EQ(ccm::fdim(8.0, 8.0), std::fdim(8.0, 8.0));
-	EXPECT_EQ(ccm::fdim(16.0, 16.0), std::fdim(16.0, 16.0));
-	EXPECT_EQ(ccm::fdim(32.0, 32.0), std::fdim(32.0, 32.0));
+	// Arrange
+	const auto & param{GetParam()};
 
-	EXPECT_EQ(ccm::fdim(1.0, 0.0), std::fdim(1.0, 0.0));
-	EXPECT_EQ(ccm::fdim(0.0, 1.0), std::fdim(0.0, 1.0));
-	EXPECT_EQ(ccm::fdim(0.0, 0.0), std::fdim(0.0, 0.0));
-	EXPECT_EQ(ccm::fdim(-1.0, 1.0), std::fdim(-1.0, 1.0));
-	EXPECT_EQ(ccm::fdim(1.0, -1.0), std::fdim(1.0, -1.0));
-	EXPECT_EQ(ccm::fdim(-1.0, -1.0), std::fdim(-1.0, -1.0));
+	// Act
+	const auto actual{ccm::fdim(param.x, param.y)};
+
+	// Assert
+	if (std::isnan(param.expected))
+	{
+		EXPECT_TRUE(std::isnan(actual)) << "ccm::fdim(" << param.x << ", " << param.y << ") expected to be NaN. Instead got " << actual << ".";
+	}
+	else
+	{
+		EXPECT_EQ(actual, param.expected) << "ccm::fdim(" << param.x << ", " << param.y << ") expected to equal " << param.expected << ". Instead got "
+										  << actual << ".";
+	}
 }
 
-TEST(CcmathBasicTests, FdimFloat)
+TEST_P(CcmathFDimLongDoubleTests, FDimWithLongDoubleReturnsAppropriateValue)
 {
-    EXPECT_EQ(ccm::fdim(1.0F, 1.0F), std::fdim(1.0F, 1.0F));
-    EXPECT_EQ(ccm::fdim(2.0F, 2.0F), std::fdim(2.0F, 2.0F));
-    EXPECT_EQ(ccm::fdim(4.0F, 4.0F), std::fdim(4.0F, 4.0F));
-    EXPECT_EQ(ccm::fdim(8.0F, 8.0F), std::fdim(8.0F, 8.0F));
-    EXPECT_EQ(ccm::fdim(16.0F, 16.0F), std::fdim(16.0F, 16.0F));
-    EXPECT_EQ(ccm::fdim(32.0F, 32.0F), std::fdim(32.0F, 32.0F));
+	// Arrange
+	const auto & param{GetParam()};
 
-    EXPECT_EQ(ccm::fdim(1.0F, 0.0F), std::fdim(1.0F, 0.0F));
-    EXPECT_EQ(ccm::fdim(0.0F, 1.0F), std::fdim(0.0F, 1.0F));
-    EXPECT_EQ(ccm::fdim(0.0F, 0.0F), std::fdim(0.0F, 0.0F));
-    EXPECT_EQ(ccm::fdim(-1.0F, 1.0F), std::fdim(-1.0F, 1.0F));
-    EXPECT_EQ(ccm::fdim(1.0F, -1.0F), std::fdim(1.0F, -1.0F));
-    EXPECT_EQ(ccm::fdim(-1.0F, -1.0F), std::fdim(-1.0F, -1.0F));
+	// Act
+	const auto actual{ccm::fdim(param.x, param.y)};
+
+	// Assert
+	if (std::isnan(param.expected))
+	{
+		EXPECT_TRUE(std::isnan(actual)) << "ccm::fdim(" << param.x << ", " << param.y << ") expected to be NaN. Instead got " << actual << ".";
+	}
+	else
+	{
+		EXPECT_EQ(actual, param.expected) << "ccm::fdim(" << param.x << ", " << param.y << ") expected to equal " << param.expected << ". Instead got "
+										  << actual << ".";
+	}
 }
 
-TEST(CcmathBasicTests, FdimLongDouble)
+TEST(CcmathBasicTests, FdimCanBeEvaluatedAtCompileTime)
 {
-    EXPECT_EQ(ccm::fdim(1.0L, 1.0L), std::fdim(1.0L, 1.0L));
-    EXPECT_EQ(ccm::fdim(2.0L, 2.0L), std::fdim(2.0L, 2.0L));
-    EXPECT_EQ(ccm::fdim(4.0L, 4.0L), std::fdim(4.0L, 4.0L));
-    EXPECT_EQ(ccm::fdim(8.0L, 8.0L), std::fdim(8.0L, 8.0L));
-    EXPECT_EQ(ccm::fdim(16.0L, 16.0L), std::fdim(16.0L, 16.0L));
-    EXPECT_EQ(ccm::fdim(32.0L, 32.0L), std::fdim(32.0L, 32.0L));
+	// Act
+	constexpr auto fdim{ccm::fdim(1.0, 1.0)};
 
-    EXPECT_EQ(ccm::fdim(1.0L, 0.0L), std::fdim(1.0L, 0.0L));
-    EXPECT_EQ(ccm::fdim(0.0L, 1.0L), std::fdim(0.0L, 1.0L));
-    EXPECT_EQ(ccm::fdim(0.0L, 0.0L), std::fdim(0.0L, 0.0L));
-    EXPECT_EQ(ccm::fdim(-1.0L, 1.0L), std::fdim(-1.0L, 1.0L));
-    EXPECT_EQ(ccm::fdim(1.0L, -1.0L), std::fdim(1.0L, -1.0L));
-    EXPECT_EQ(ccm::fdim(-1.0L, -1.0L), std::fdim(-1.0L, -1.0L));
-}
-
-TEST(CcmathBasicTests, FdimEdgeCases)
-{
-
+	// Assert
+	static_assert(fdim == 0.0, "fdim has failed testing that it is static_assert-able!");
 }


### PR DESCRIPTION
<!-- Please target the "dev" branch when creating a pull request to ensure you are using the latest version of ccmath -->
Tests modified: 
- fdim_test.cpp
- abs_test.cpp

Converted to be parameterized tests for each type (double, long double, float, ...)
Verified that `ccm::fdim` and `ccm::abs` can be evaluated at compile time.
Added additional edge cases for each type under test.