### PR TITLE
Implements rint

### DIFF
--- a/include/ccmath/math/nearest/rint.hpp
+++ b/include/ccmath/math/nearest/rint.hpp
@@ -10,7 +10,239 @@
 
 #pragma once
 
+#include <ccmath/internal/support/fenv/fenv_support.hpp>
+#include <ccmath/internal/support/fenv/rounding_mode.hpp>
+#include <ccmath/internal/support/fp/directional_rounding_utils.hpp>
+#include <ccmath/math/compare/isinf.hpp>
+#include <ccmath/math/compare/isnan.hpp>
+#include <type_traits>
+
 namespace ccm
 {
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value (in floating-point format), using the current rounding mode. The library provides
+	 * overloads of std::rint for all cv-unqualified floating-point types as the type of the parameter num.
+	 * @tparam T The type of the number.
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	template <class T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
+	constexpr T rint(T num)
+	{
+		if (ccm::isinf(num) || ccm::isnan(num)) { ccm::support::fenv::raise_except_if_required(FE_INVALID); }
+		const auto rounding_mode{ccm::support::fenv::get_rounding_mode()};
+		return ccm::support::fp::directional_round(num, rounding_mode);
+	}
+
+	/**
+	 * @brief Additional overloads are provided for all integer types, which are treated as double.
+	 * @tparam Integer The type of the integral value.
+	 * @param num An integral value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	template <class Integer, std::enable_if_t<std::is_integral_v<Integer>, bool> = true>
+	constexpr double rint(Integer num)
+	{
+		return static_cast<double>(num);
+	}
+
+	/**
+	 * @brief Additional overloads are provided for all integer types, which are treated as double.
+	 * @tparam Integer The type of the integral value.
+	 * @param num An integral value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	template <class Integer, std::enable_if_t<std::is_integral_v<Integer>, bool> = true>
+	constexpr long lrint(Integer num)
+	{
+		return static_cast<long>(num);
+	}
+
+	/**
+	 * @brief Additional overloads are provided for all integer types, which are treated as double.
+	 * @tparam Integer The type of the integral value.
+	 * @param num An integral value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	template <class Integer, std::enable_if_t<std::is_integral_v<Integer>, bool> = true>
+	constexpr long long llrint(Integer num)
+	{
+		return static_cast<long long>(num);
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value (in floating-point format), using the current rounding mode. The library provides
+	 * overloads of std::rint for all cv-unqualified floating-point types as the type of the parameter num.
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr float rint(float num)
+	{
+		return ccm::rint<float>(num);
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value (in floating-point format), using the current rounding mode. The library provides
+	 * overloads of std::rint for all cv-unqualified floating-point types as the type of the parameter num.
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr double rint(double num)
+	{
+		return ccm::rint<double>(num);
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value (in floating-point format), using the current rounding mode. The library provides
+	 * overloads of std::rint for all cv-unqualified floating-point types as the type of the parameter num.
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr long double rint(long double num)
+	{
+		return ccm::rint<long double>(num);
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value (in floating-point format), using the current rounding mode. The library provides
+	 * overloads of std::rint for all cv-unqualified floating-point types as the type of the parameter num.
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr float rintf(float num)
+	{
+		return ccm::rint<float>(num);
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value (in floating-point format), using the current rounding mode. The library provides
+	 * overloads of std::rint for all cv-unqualified floating-point types as the type of the parameter num.
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr long double rintl(long double num)
+	{
+		return ccm::rint<long double>(num);
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value, using the current rounding mode. The library provides overloads of std::lrint and
+	 * std::llrint for all cv-unqualified floating-point types as the type of the parameter num.(
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr long lrint(float num)
+	{
+		return static_cast<long>(ccm::rint(num));
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value, using the current rounding mode. The library provides overloads of std::lrint and
+	 * std::llrint for all cv-unqualified floating-point types as the type of the parameter num.(
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr long lrint(double num)
+	{
+		if (ccm::isnan(num))
+		{
+			ccm::support::fenv::raise_except_if_required(FE_INVALID);
+			return std::numeric_limits<long>::min();
+		}
+		return static_cast<long>(ccm::rint(num));
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value, using the current rounding mode. The library provides overloads of std::lrint and
+	 * std::llrint for all cv-unqualified floating-point types as the type of the parameter num.(
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr long lrint(long double num)
+	{
+		return static_cast<long>(ccm::rint(num));
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value, using the current rounding mode. The library provides overloads of std::lrint and
+	 * std::llrint for all cv-unqualified floating-point types as the type of the parameter num.(
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr long lrintf(float num)
+	{
+		return static_cast<long>(ccm::rint(num));
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value, using the current rounding mode. The library provides overloads of std::lrint and
+	 * std::llrint for all cv-unqualified floating-point types as the type of the parameter num.(
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr long lrintl(long double num)
+	{
+		return static_cast<long>(ccm::rint(num));
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value, using the current rounding mode. The library provides overloads of std::lrint and
+	 * std::llrint for all cv-unqualified floating-point types as the type of the parameter num.(
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr long long llrint(float num)
+	{
+		return static_cast<long long>(ccm::rint(num));
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value, using the current rounding mode. The library provides overloads of std::lrint and
+	 * std::llrint for all cv-unqualified floating-point types as the type of the parameter num.(
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr long long llrint(double num)
+	{
+		if (ccm::isnan(num))
+		{
+			ccm::support::fenv::raise_except_if_required(FE_INVALID);
+			return std::numeric_limits<long long>::min();
+		}
+		return static_cast<long long>(ccm::rint(num));
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value, using the current rounding mode. The library provides overloads of std::lrint and
+	 * std::llrint for all cv-unqualified floating-point types as the type of the parameter num.(
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr long long llrint(long double num)
+	{
+		return static_cast<long long>(ccm::rint(num));
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value, using the current rounding mode. The library provides overloads of std::lrint and
+	 * std::llrint for all cv-unqualified floating-point types as the type of the parameter num.(
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr long long llrintf(float num)
+	{
+		return static_cast<long long>(ccm::rint(num));
+	}
+
+	/**
+	 * @brief Rounds the floating-point argument num to an integer value, using the current rounding mode. The library provides overloads of std::lrint and
+	 * std::llrint for all cv-unqualified floating-point types as the type of the parameter num.(
+	 * @param num A floating-point value.
+	 * @return If no errors occur, the nearest integer value to num, according to the current rounding mode, is returned.
+	 */
+	constexpr long long llrintl(long double num)
+	{
+		return static_cast<long long>(ccm::rint(num));
+	}
 
 } // namespace ccm

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,11 +92,32 @@ target_link_libraries(${PROJECT_NAME}-fmanip PRIVATE
 )
 
 add_executable(${PROJECT_NAME}-nearest)
+set(ROUNDING_MODES
+    FE_DOWNWARD
+    FE_UPWARD
+    FE_TONEAREST
+    FE_TOWARDZERO
+)
+set(GENERATED_SOURCES)
+foreach(MODE IN LISTS ROUNDING_MODES)
+    # Set the output file name based on the rounding mode
+    string(REPLACE "FE_" "" MODE_SUFFIX ${MODE})
+    set(OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/rounding_${MODE_SUFFIX}.cpp")
+    set(ROUNDING_MODE "FE_${MODE_SUFFIX}")
+    # Configure the template file to generate the specific cpp file
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/nearest/rint_test.cpp.in
+        ${OUTPUT_FILE}
+        @ONLY
+    )
+    list(APPEND GENERATED_SOURCES ${OUTPUT_FILE})
+endforeach()
 target_sources(${PROJECT_NAME}-nearest PRIVATE
         nearest/floor_test.cpp
         nearest/nearbyint_test.cpp
         nearest/trunc_test.cpp
-
+        nearest/rint_test_compile_time.cpp
+        ${GENERATED_SOURCES}
 )
 target_link_libraries(${PROJECT_NAME}-nearest PRIVATE
         ccmath::test

--- a/test/nearest/rint_test.cpp.in
+++ b/test/nearest/rint_test.cpp.in
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2024-Present Ian Pike
+ * Copyright (c) 2024-Present ccmath contributors
+ *
+ * This library is provided under the MIT License.
+ * See LICENSE for more information.
+ */
+
+#include <ccmath/math/nearest/rint.hpp>
+#include <ccmath/internal/support/is_constant_evaluated.hpp>
+
+#include <cfenv>
+#include <cmath>
+#include <functional>
+#include <ranges>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+	using testing::TestWithParam;
+	using testing::ValuesIn;
+
+	template <typename InputType, typename OutputType = InputType>
+	struct RIntTestParams
+	{
+		InputType input{};
+		OutputType output{};
+	};
+
+	template <typename T>
+	std::vector<T> make_test_params()
+	{
+		return std::vector<T>{
+			static_cast<T>(-0.0),
+			static_cast<T>(-0.5),
+			static_cast<T>(-1.0),
+			static_cast<T>(-1.5),
+			static_cast<T>(-1.999),
+			static_cast<T>(-2.001),
+			static_cast<T>(-123.0),
+			static_cast<T>(0.0),
+			static_cast<T>(0.5),
+			static_cast<T>(1.0),
+			static_cast<T>(1.5),
+			static_cast<T>(1.999),
+			static_cast<T>(2.001),
+			static_cast<T>(123.0),
+			std::numeric_limits<T>::max(),
+			std::numeric_limits<T>::infinity(),
+			std::numeric_limits<T>::quiet_NaN(),
+			std::numeric_limits<T>::denorm_min(),
+			-std::numeric_limits<T>::max(),
+			-std::numeric_limits<T>::infinity(),
+		};
+	}
+
+	// All of the function calls that raise FE_INVALID.
+	// clang-format off
+	const std::vector<std::function<void()>> k_values_that_will_raise_FE_INVALID{
+		[] { return ccm::rint(std::numeric_limits<double>::infinity()); },
+		[] { return ccm::rint(-std::numeric_limits<double>::infinity()); },
+		[] { return ccm::rint(std::numeric_limits<double>::quiet_NaN()); },
+		[] { return ccm::rint(std::numeric_limits<float>::infinity()); },
+		[] { return ccm::rint(-std::numeric_limits<float>::infinity()); },
+		[] { return ccm::rint(std::numeric_limits<float>::quiet_NaN()); },
+		[] { return ccm::rintf(std::numeric_limits<float>::infinity()); },
+		[] { return ccm::rintf(-std::numeric_limits<float>::infinity()); },
+		[] { return ccm::rintf(std::numeric_limits<float>::quiet_NaN()); },
+		[] { return ccm::rint(std::numeric_limits<long double>::infinity()); },
+		[] { return ccm::rint(-std::numeric_limits<long double>::infinity()); },
+		[] { return ccm::rint(std::numeric_limits<long double>::quiet_NaN()); },
+		[] { return ccm::rintl(std::numeric_limits<long double>::infinity()); },
+		[] { return ccm::rintl(-std::numeric_limits<long double>::infinity()); },
+		[] { return ccm::rintl(std::numeric_limits<long double>::quiet_NaN()); },
+
+		[] { return ccm::lrint(std::numeric_limits<double>::infinity()); },
+		[] { return ccm::lrint(-std::numeric_limits<double>::infinity()); },
+		[] { return ccm::lrint(std::numeric_limits<double>::quiet_NaN()); },
+		[] { return ccm::lrint(std::numeric_limits<float>::infinity()); },
+		[] { return ccm::lrint(-std::numeric_limits<float>::infinity()); },
+		[] { return ccm::lrint(std::numeric_limits<float>::quiet_NaN()); },
+		[] { return ccm::lrintf(std::numeric_limits<float>::infinity()); },
+		[] { return ccm::lrintf(-std::numeric_limits<float>::infinity()); },
+		[] { return ccm::lrintf(std::numeric_limits<float>::quiet_NaN()); },
+		[] { return ccm::lrint(std::numeric_limits<long double>::infinity()); },
+		[] { return ccm::lrint(-std::numeric_limits<long double>::infinity()); },
+		[] { return ccm::lrint(std::numeric_limits<long double>::quiet_NaN()); },
+		[] { return ccm::lrintl(std::numeric_limits<long double>::infinity()); },
+		[] { return ccm::lrintl(-std::numeric_limits<long double>::infinity()); },
+		[] { return ccm::lrintl(std::numeric_limits<long double>::quiet_NaN()); },
+
+		[] { return ccm::llrint(std::numeric_limits<double>::infinity()); },
+		[] { return ccm::llrint(-std::numeric_limits<double>::infinity()); },
+		[] { return ccm::llrint(std::numeric_limits<double>::quiet_NaN()); },
+		[] { return ccm::llrint(std::numeric_limits<float>::infinity()); },
+		[] { return ccm::llrint(-std::numeric_limits<float>::infinity()); },
+		[] { return ccm::llrint(std::numeric_limits<float>::quiet_NaN()); },
+		[] { return ccm::llrintf(std::numeric_limits<float>::infinity()); },
+		[] { return ccm::llrintf(-std::numeric_limits<float>::infinity()); },
+		[] { return ccm::llrintf(std::numeric_limits<float>::quiet_NaN()); },
+		[] { return ccm::llrint(std::numeric_limits<long double>::infinity()); },
+		[] { return ccm::llrint(-std::numeric_limits<long double>::infinity()); },
+		[] { return ccm::llrint(std::numeric_limits<long double>::quiet_NaN()); },
+		[] { return ccm::llrintl(std::numeric_limits<long double>::infinity()); },
+		[] { return ccm::llrintl(-std::numeric_limits<long double>::infinity()); },
+		[] { return ccm::llrintl(std::numeric_limits<long double>::quiet_NaN()); },
+	};
+	// clang-format on
+
+	const std::vector<float> k_float_test_params{make_test_params<float>()};
+	const std::vector<double> k_double_test_params{make_test_params<double>()};
+	const std::vector<long double> k_long_double_test_params{make_test_params<long double>()};
+
+	template <typename InputType, typename OutputType = InputType>
+	auto createTestParams(const std::vector<InputType> & inputValues, OutputType (*func)(InputType))
+	{
+		std::vector<RIntTestParams<InputType, OutputType>> result;
+		std::transform(inputValues.cbegin(), inputValues.cend(), std::back_inserter(result),
+					   [func](InputType value) { return RIntTestParams<InputType, OutputType>{value, func(value)}; });
+		return result;
+	}
+
+} // namespace
+
+template <typename T>
+class CcmathRIntBaseTests_@ROUNDING_MODE@ : public TestWithParam<T>
+{
+protected:
+	CcmathRIntBaseTests_@ROUNDING_MODE@() { std::fesetround(@ROUNDING_MODE@); }
+};
+
+// ccm::rint, ccm::rintl, ccm::rintf
+class CcmathRIntFloatTests_@ROUNDING_MODE@ : public CcmathRIntBaseTests_@ROUNDING_MODE@<RIntTestParams<float>>
+{
+};
+
+class CcmathRIntDoubleTests_@ROUNDING_MODE@ : public CcmathRIntBaseTests_@ROUNDING_MODE@<RIntTestParams<double>>
+{
+};
+
+class CcmathRIntLongDoubleTests_@ROUNDING_MODE@ : public CcmathRIntBaseTests_@ROUNDING_MODE@<RIntTestParams<long double>>
+{
+};
+
+INSTANTIATE_TEST_SUITE_P(RIntFloatTests, CcmathRIntFloatTests_@ROUNDING_MODE@, ValuesIn(createTestParams<float>(k_float_test_params, std::rint)));
+INSTANTIATE_TEST_SUITE_P(RIntDoubleTests, CcmathRIntDoubleTests_@ROUNDING_MODE@, ValuesIn(createTestParams<double>(k_double_test_params, std::rint)));
+INSTANTIATE_TEST_SUITE_P(RIntLongDoubleTests, CcmathRIntLongDoubleTests_@ROUNDING_MODE@, ValuesIn(createTestParams<long double>(k_long_double_test_params, std::rint)));
+
+TEST_P(CcmathRIntFloatTests_@ROUNDING_MODE@, RIntFloat)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::rint(params.input)};
+	if (std::isnan(params.input)) { EXPECT_TRUE(std::isnan(actual)); }
+	else { EXPECT_EQ(params.output, actual); }
+}
+
+TEST_P(CcmathRIntFloatTests_@ROUNDING_MODE@, RIntFFloat)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::rintf(params.input)};
+	if (std::isnan(params.input)) { EXPECT_TRUE(std::isnan(actual)); }
+	else { EXPECT_EQ(params.output, actual); }
+}
+
+TEST_P(CcmathRIntDoubleTests_@ROUNDING_MODE@, RIntDouble)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::rint(params.input)};
+	if (std::isnan(params.input)) { EXPECT_TRUE(std::isnan(actual)); }
+	else { EXPECT_EQ(params.output, actual); }
+}
+
+TEST_P(CcmathRIntLongDoubleTests_@ROUNDING_MODE@, RIntLongDouble)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::rint(params.input)};
+	if (std::isnan(params.input)) { EXPECT_TRUE(std::isnan(actual)); }
+	else { EXPECT_EQ(params.output, actual); }
+}
+
+TEST_P(CcmathRIntLongDoubleTests_@ROUNDING_MODE@, RIntLLongDouble)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::rintl(params.input)};
+	if (std::isnan(params.input)) { EXPECT_TRUE(std::isnan(actual)); }
+	else { EXPECT_EQ(params.output, actual); }
+}
+
+// ccm::lrint, ccm::lrintf, ccm::lrintl
+class CcmathLRIntFloatTests_@ROUNDING_MODE@ : public CcmathRIntBaseTests_@ROUNDING_MODE@<RIntTestParams<float, long>>
+{
+};
+
+class CcmathLRIntDoubleTests_@ROUNDING_MODE@ : public CcmathRIntBaseTests_@ROUNDING_MODE@<RIntTestParams<double, long>>
+{
+};
+
+class CcmathLRIntLongDoubleTests_@ROUNDING_MODE@ : public CcmathRIntBaseTests_@ROUNDING_MODE@<RIntTestParams<long double, long>>
+{
+};
+
+INSTANTIATE_TEST_SUITE_P(LRIntFloatTests, CcmathLRIntFloatTests_@ROUNDING_MODE@, ValuesIn(createTestParams<float, long>(k_float_test_params, std::lrint)));
+INSTANTIATE_TEST_SUITE_P(LRIntDoubleTests, CcmathLRIntDoubleTests_@ROUNDING_MODE@, ValuesIn(createTestParams<double, long>(k_double_test_params, std::lrint)));
+INSTANTIATE_TEST_SUITE_P(LRIntLongDoubleTests, CcmathLRIntLongDoubleTests_@ROUNDING_MODE@, ValuesIn(createTestParams<long double, long>(k_long_double_test_params, std::lrint)));
+
+TEST_P(CcmathLRIntFloatTests_@ROUNDING_MODE@, LRIntFloat)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::lrint(params.input)};
+	EXPECT_EQ(params.output, actual);
+}
+
+TEST_P(CcmathLRIntFloatTests_@ROUNDING_MODE@, LRIntFFloat)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::lrintf(params.input)};
+	EXPECT_EQ(params.output, actual);
+}
+
+TEST_P(CcmathLRIntDoubleTests_@ROUNDING_MODE@, LRIntDouble)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::lrint(params.input)};
+	EXPECT_EQ(params.output, actual);
+}
+
+TEST_P(CcmathLRIntLongDoubleTests_@ROUNDING_MODE@, LRIntLongDouble)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::lrint(params.input)};
+	EXPECT_EQ(params.output, actual);
+}
+
+TEST_P(CcmathLRIntLongDoubleTests_@ROUNDING_MODE@, LRIntLLongDouble)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::lrintl(params.input)};
+	EXPECT_EQ(params.output, actual);
+}
+
+// ccm::llrint, ccm::llrintf, ccm::llrintl
+class CcmathLLRIntFloatTests_@ROUNDING_MODE@ : public CcmathRIntBaseTests_@ROUNDING_MODE@<RIntTestParams<float, long long>>
+{
+};
+
+class CcmathLLRIntDoubleTests_@ROUNDING_MODE@ : public CcmathRIntBaseTests_@ROUNDING_MODE@<RIntTestParams<double, long long>>
+{
+};
+
+class CcmathLLRIntLongDoubleTests_@ROUNDING_MODE@ : public CcmathRIntBaseTests_@ROUNDING_MODE@<RIntTestParams<long double, long long>>
+{
+};
+
+INSTANTIATE_TEST_SUITE_P(LLRIntFloatTests, CcmathLLRIntFloatTests_@ROUNDING_MODE@, ValuesIn(createTestParams<float, long long>(k_float_test_params, std::llrint)));
+INSTANTIATE_TEST_SUITE_P(LLRIntDoubleTests, CcmathLLRIntDoubleTests_@ROUNDING_MODE@, ValuesIn(createTestParams<double, long long>(k_double_test_params, std::llrint)));
+INSTANTIATE_TEST_SUITE_P(LLRIntLongDoubleTests, CcmathLLRIntLongDoubleTests_@ROUNDING_MODE@,
+						 ValuesIn(createTestParams<long double, long long>(k_long_double_test_params, std::llrint)));
+
+TEST_P(CcmathLLRIntFloatTests_@ROUNDING_MODE@, LLRIntFloat)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::llrint(params.input)};
+	EXPECT_EQ(params.output, actual);
+}
+
+TEST_P(CcmathLLRIntFloatTests_@ROUNDING_MODE@, LLRIntFFloat)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::llrintf(params.input)};
+	EXPECT_EQ(params.output, actual);
+}
+
+TEST_P(CcmathLLRIntDoubleTests_@ROUNDING_MODE@, LLRIntDouble)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::llrint(params.input)};
+	EXPECT_EQ(params.output, actual);
+}
+
+TEST_P(CcmathLLRIntLongDoubleTests_@ROUNDING_MODE@, LLRIntLongDouble)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::llrint(params.input)};
+	EXPECT_EQ(params.output, actual);
+}
+
+TEST_P(CcmathLLRIntLongDoubleTests_@ROUNDING_MODE@, LLRIntLLongDouble)
+{
+	const auto & params{GetParam()};
+	const auto actual{ccm::llrintl(params.input)};
+	EXPECT_EQ(params.output, actual);
+}
+
+// FE_INVALID raised tests
+class RIntRaisesFE_INVALIDTests_@ROUNDING_MODE@ : public CcmathRIntBaseTests_@ROUNDING_MODE@<std::function<void()>>
+{
+protected:
+	void SetUp() override { std::feclearexcept(FE_ALL_EXCEPT); }
+
+	void TearDown() override { std::feclearexcept(FE_ALL_EXCEPT); }
+};
+
+INSTANTIATE_TEST_SUITE_P(FE_INVALIDRaisedTests, RIntRaisesFE_INVALIDTests_@ROUNDING_MODE@, ValuesIn(k_values_that_will_raise_FE_INVALID));
+
+TEST_P(RIntRaisesFE_INVALIDTests_@ROUNDING_MODE@, FE_INVALIDIsRaised)
+{
+	GetParam()();
+	EXPECT_TRUE(std::fetestexcept(FE_INVALID));
+	EXPECT_FALSE(ccm::support::is_constant_evaluated());
+}

--- a/test/nearest/rint_test_compile_time.cpp
+++ b/test/nearest/rint_test_compile_time.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2024-Present Ian Pike
+ * Copyright (c) 2024-Present ccmath contributors
+ *
+ * This library is provided under the MIT License.
+ * See LICENSE for more information.
+ */
+
+#include <ccmath/math/nearest/rint.hpp>
+
+#include <cfenv>
+#include <cmath>
+#include <functional>
+#include <ranges>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+// Disabling test case ccm::nearbyintl if run on clang linux.
+#ifdef __clang__
+	#ifdef __linux__
+		#define CLANG_LINUX
+	#endif
+#endif
+
+// Compile Time Tests
+
+#ifndef CLANG_LINUX
+TEST(CcmathNearestTests, CcmRIntDoubleCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::rint(1.0)};
+	static_assert(rint == 1.0);
+}
+
+TEST(CcmathNearestTests, CcmRIntFloatCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::rint(1.0f)};
+	static_assert(rint == 1.0f);
+}
+
+TEST(CcmathNearestTests, CcmRIntFFloatCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::rintf(1.0f)};
+	static_assert(rint == 1.0f);
+}
+
+TEST(CcmathNearestTests, CcmRIntLongDoubleCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::rint(1.0l)};
+	static_assert(rint == 1.0l);
+}
+
+TEST(CcmathNearestTests, CcmRIntLLongDoubleCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::rintl(1.0l)};
+	static_assert(rint == 1.0l);
+}
+
+TEST(CcmathNearestTests, CcmLRIntDoubleCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::lrint(1.0)};
+	static_assert(rint == 1.0);
+}
+
+TEST(CcmathNearestTests, CcmLRIntFloatCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::lrint(1.0f)};
+	static_assert(rint == 1.0f);
+}
+
+TEST(CcmathNearestTests, CcmLRIntFFloatCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::lrintf(1.0f)};
+	static_assert(rint == 1.0f);
+}
+
+TEST(CcmathNearestTests, CcmLRIntLongDoubleCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::lrint(1.0l)};
+	static_assert(rint == 1.0l);
+}
+
+TEST(CcmathNearestTests, CcmLRIntLLongDoubleCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::lrintl(1.0l)};
+	static_assert(rint == 1.0l);
+}
+
+TEST(CcmathNearestTests, CcmLLRIntDoubleCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::llrint(1.0)};
+	static_assert(rint == 1.0);
+}
+
+TEST(CcmathNearestTests, CcmLLRIntFloatCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::llrint(1.0f)};
+	static_assert(rint == 1.0f);
+}
+
+TEST(CcmathNearestTests, CcmLLRIntFFloatCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::llrintf(1.0f)};
+	static_assert(rint == 1.0f);
+}
+
+TEST(CcmathNearestTests, CcmLLRIntLongDoubleCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::llrint(1.0l)};
+	static_assert(rint == 1.0l);
+}
+
+TEST(CcmathNearestTests, CcmLLRIntLLongDoubleCanBeEvaluatedAtCompileTime)
+{
+	constexpr auto rint{ccm::llrintl(1.0l)};
+	static_assert(rint == 1.0l);
+}
+#endif
+
+// Remove #define CLANG_LINUX
+#ifdef CLANG_LINUX
+	#undef CLANG_LINUX
+#endif


### PR DESCRIPTION
<!-- Please target the "dev" branch when creating a pull request to ensure you are using the latest version of ccmath -->
Functions implemented:

- ccm::rint(float)
- ccm::rint(double)
- ccm::rint(long double)
- ccm::rintl(long double)
- ccm::rintf(float)

- ccm::lrint(float)
- ccm::lrint(double)
- ccm::lrint(long double)
- ccm::lrintl(long double)
- ccm::lrintf(float)

- ccm::llrint(float)
- ccm::llrint(double)
- ccm::llrint(long double)
- ccm::llrintl(long double)
- ccm::llrintf(long double)

Tests written for:

- Common and edge case conditions for `float`, `double`, and `long
  double` inputs.
- Assert that FE_INVALID is raised for +/- infinity values and NaN
  values.
- Asserts that functions can be evaluated at compile time.
