### PR TITLE
fix: return infinity for hypot overflow

### DIFF
--- a/include/ccmath/math/power/impl/hypot_impl.hpp
+++ b/include/ccmath/math/power/impl/hypot_impl.hpp
@@ -17,6 +17,7 @@
 #include "ccmath/math/compare/isnan.hpp"
 #include "ccmath/math/power/sqrt.hpp"
 
+#include <limits>
 #include <type_traits>
 
 namespace ccm::internal::impl
@@ -44,6 +45,10 @@ namespace ccm::internal::impl
 		}
 
 		const T ratio = y / x;
-		return x * ccm::sqrt(static_cast<T>(1) + ratio * ratio);
+		const T scale = ccm::sqrt(static_cast<T>(1) + ratio * ratio);
+
+		if (x > std::numeric_limits<T>::max() / scale) { return fp_bits_t::inf().get_val(); }
+
+		return x * scale;
 	}
 } // namespace ccm::internal::impl

--- a/tests/power/hypot_cbrt_test.cpp
+++ b/tests/power/hypot_cbrt_test.cpp
@@ -96,3 +96,13 @@ TEST(CcmathPowerTests, HypotCbrtCompileTime)
 	static_assert(ccm::hypot(3.0, 0.0) == 3.0);
 	static_assert(ccm::cbrt(8.0) == 2.0);
 }
+TEST(CcmathPowerTests, HypotOverflowBoundary)
+{
+    constexpr float x = 3.40282347e38f;
+    constexpr float y = 9.18e34f;
+
+    ccm::test::ExpectSameFloatingAsStd(
+        ccm::hypot(x, y),
+        std::hypot(x, y)
+    );
+}


### PR DESCRIPTION
## Summary

Fix overflow handling in `hypot`.

Previously, when the true result exceeded the maximum
representable floating-point value, the implementation
returned the largest finite value instead of `+inf`.

This change adds an overflow check and returns `+inf`
to match the behavior of `std::hypot`. A regression
test for the overflow boundary case has also been added.

Closes #137