### PR TITLE
Move development to main and retire the dev branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,1 @@
-<!-- Please target the "dev" branch when creating a pull request to ensure you are using the latest version of ccmath -->
+<!-- Please target the "main" branch when creating a pull request. Active development happens on main; release/N.x branches receive only backported fixes. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
       interval: "monthly"
     # Allow up to 3 opened pull requests for github-actions versions.
     open-pull-requests-limit: 3
-    target-branch: "dev"
+    target-branch: "main"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "main", "release/**" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main", "dev" ]
+    branches: [ "main", "release/**" ]
   schedule:
     - cron: "0 0 * * 1"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 For help understanding how to implement elementary functions in CCMath, see
 [Approximating Functions: A Practical Guide to Sollya and Function Implementation](docs/approximating_functions/APPROXIMATING_FUNCTIONS.pdf).
 
-PRs go to the `dev` branch. Bug reports and design questions belong in
+PRs go to the `main` branch. Bug reports and design questions belong in
 [Issues](https://github.com/Rinzii/ccmath/issues) or
 [Discord](https://discord.gg/p3mVxAbdmc).
 
@@ -27,7 +27,7 @@ Apache-2.0 WITH LLVM-exception.
 ```bash
 git clone https://github.com/<your-username>/ccmath.git
 cd ccmath
-git checkout dev
+git checkout main
 git checkout -b <topic-branch>
 ```
 
@@ -40,7 +40,7 @@ ctest --preset=test-ninja-gcc-debug --output-on-failure
 ```
 
 Commit with a one-line imperative subject (no trailing period). Open a PR against
-`dev` with a short summary of what changed and how you tested it.
+`main` with a short summary of what changed and how you tested it.
 
 Implementation work should stay under `include/ccmath/` using the patterns already
 present in the function family you touch. Do not add `<cmath>` includes under
@@ -61,7 +61,7 @@ present in the function family you touch. Do not add `<cmath>` includes under
 ```bash
 git clone https://github.com/Rinzii/ccmath.git
 cd ccmath
-git checkout dev
+git checkout main
 cmake --preset=ninja-gcc-debug
 cmake --build --preset=build-ninja-gcc-debug
 ctest --preset=test-ninja-gcc-debug --output-on-failure
@@ -76,7 +76,7 @@ configure line when you need a specific standard.
 ```powershell
 git clone https://github.com/Rinzii/ccmath.git
 cd ccmath
-git checkout dev
+git checkout main
 cmake --preset=vs22-debug
 cmake --build --preset=build-vs22-debug
 ctest --preset=test-vs22-debug --output-on-failure

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 
 ## A constexpr-first `<cmath>` library for C++17 and later
 
-[![Windows CI](https://github.com/Rinzii/ccmath/actions/workflows/ci-windows.yml/badge.svg?branch=main)](https://github.com/Rinzii/ccmath/actions/workflows/ci-windows.yml?query=branch%3Amain)
-[![Linux CI](https://github.com/Rinzii/ccmath/actions/workflows/ci-linux.yml/badge.svg?branch=main)](https://github.com/Rinzii/ccmath/actions/workflows/ci-linux.yml?query=branch%3Amain)
-[![macOS CI](https://github.com/Rinzii/ccmath/actions/workflows/ci-macos.yml/badge.svg?branch=main)](https://github.com/Rinzii/ccmath/actions/workflows/ci-macos.yml?query=branch%3Amain)
+[![Release](https://img.shields.io/github/v/release/Rinzii/ccmath?sort=semver&label=release)](https://github.com/Rinzii/ccmath/releases/latest)
+[![Windows CI (main)](https://github.com/Rinzii/ccmath/actions/workflows/ci-windows.yml/badge.svg?branch=main)](https://github.com/Rinzii/ccmath/actions/workflows/ci-windows.yml?query=branch%3Amain)
+[![Linux CI (main)](https://github.com/Rinzii/ccmath/actions/workflows/ci-linux.yml/badge.svg?branch=main)](https://github.com/Rinzii/ccmath/actions/workflows/ci-linux.yml?query=branch%3Amain)
+[![macOS CI (main)](https://github.com/Rinzii/ccmath/actions/workflows/ci-macos.yml/badge.svg?branch=main)](https://github.com/Rinzii/ccmath/actions/workflows/ci-macos.yml?query=branch%3Amain)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Rinzii/ccmath/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Rinzii/ccmath)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9402/badge)](https://www.bestpractices.dev/projects/9402)
 [![License](https://img.shields.io/badge/License-Apache%202.0%20WITH%20LLVM--exception-blue.svg)](https://opensource.org/licenses/Apache-2.0)


### PR DESCRIPTION
Retires the long-lived `dev` branch and points active development at `main`.

## Changes
- **CONTRIBUTING.md**: PRs now target `main`; all `git checkout dev` steps updated to `main`.
- **README.md**: added a release-version badge tracking the latest GitHub release; relabeled CI badges as "(main)" to make the tracked branch explicit.
- **.github/PULL_REQUEST_TEMPLATE.md**: PR target guidance points at `main`.
- **.github/dependabot.yml**: `target-branch` changed from `dev` to `main`.
- **.github/workflows/codeql.yml**: scans `main` and `release/**` instead of `main`/`dev`.

The platform CI workflows already trigger on `branches: ['**']`, so `main` and any future `release/*` branch are covered without change.

## Context
The `dev` branch is being retired. Its content was already merged into `main` via the v0.3.0 squash (#123), so `main` and `dev` had identical trees at the time of this change.