### PR TITLE
Remove dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions" # Necessary to update action hashes.
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    # Allow up to 3 opened pull requests for github-actions versions.
-    open-pull-requests-limit: 3
-    target-branch: "main"


### PR DESCRIPTION
Removes `.github/dependabot.yml`. Dependabot version updates are no longer needed for this repository.

Open dependabot PRs (#143, #144) have been closed and their branches deleted as part of this cleanup.